### PR TITLE
Colab, not Collab

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Models (.ckpt files) must be separately downloaded and are required to run Stabl
 * [RealESRGAN Models](https://github.com/xinntao/Real-ESRGAN/releases/) - Download location for the latest RealESRGAN models required to use upscaling by many forks implementing it. Different models exist for realistic and anime content. Please refer to the fork documentation to identify the ones you need.
 
  
-## Online Demos & Collabs
+## Online Demos & Notebooks
 
 * [HuggingFace/StabilityAI](https://huggingface.co/spaces/stabilityai/stable-diffusion) - The official demo on HuggingFace Spaces.
-* 🖊️💵 [Offical Collab](https://colab.research.google.com/github/huggingface/notebooks/blob/main/diffusers/stable_diffusion.ipynb) - The official, optimized collab for running SD on Google Cloud. Due to VRAM requirements required Collab Pro to create images.
+* 🖊️💵 [Offical Colab](https://colab.research.google.com/github/huggingface/notebooks/blob/main/diffusers/stable_diffusion.ipynb) - The official, optimized colab for running SD on Google Cloud. Due to VRAM requirements required Colab Pro to create images.
 * [andreasjansson/stable-diffusion-animation](https://replicate.com/andreasjansson/stable-diffusion-animation) - Animate between prompts.
 
 ## Complimentary Models and Tools


### PR DESCRIPTION
Corrected _Google Collab_ to _Google Colab_(oratory). Also generalized the section title to “Notebooks”.

The PR template is not applicable.
